### PR TITLE
Added optional argument for filename input

### DIFF
--- a/slab/psychoacoustics.py
+++ b/slab/psychoacoustics.py
@@ -965,11 +965,12 @@ class ResultsFile:
 
     name = property(fget=lambda self: self.path.name, doc='The name of the results file.')
 
-    def __init__(self, subject='test', folder=None):
+    def __init__(self, subject='test', folder=None, filename=None):
         self.subject = subject
         if folder is None:
             folder = results_folder
-        self.path = pathlib.Path(folder / pathlib.Path(subject) / pathlib.Path(subject +
+        filename = '_'.join(filter(None, (subject, filename)))
+        self.path = pathlib.Path(folder / pathlib.Path(subject) / pathlib.Path(filename +
                                  datetime.datetime.now().strftime("_%Y-%m-%d-%H-%M-%S") + '.txt'))
         # make the Results folder and subject subfolder
         self.path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Filename can be extended by an optional 'filename' input parameter. If None, it gets ignored; if not None, it gets concatenated to the 'subject' string separated by '_'.