### PR TITLE
Added a sensible equality check to `Signal`.

### DIFF
--- a/slab/signal.py
+++ b/slab/signal.py
@@ -176,6 +176,26 @@ class Signal:
     def __len__(self):
         return self.n_samples
 
+    def __eq__(self, other: "Signal") -> bool:
+        """Sensible equality check for Signal objects.
+
+        Signals are considered equal if they have the same data and samplerate.
+
+        Args:
+            other (Signal): the other Signal object to compare to.
+
+        Returns:
+            bool: True if the Signals are equal, False otherwise.
+
+        """
+        if not isinstance(other, type(self)):
+            return False
+        if self.samplerate != other.samplerate:
+            return False
+        if not numpy.array_equal(self.data, other.data):
+            return False
+        return True
+
     # static methods (belong to the class, but can be called without creating an instance)
     @staticmethod
     def in_samples(ctime, samplerate):

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -119,3 +119,24 @@ def test_delay():
             delayed_channel = delayed.channel(channel)
             numpy.testing.assert_almost_equal(delayed_channel[:delay_n_samples].flatten(),
                                               numpy.zeros(delay_n_samples), decimal=7)
+
+
+def test_signal_equals():
+    """Test that two signals are equal if they have the same data and samplerate."""
+    n_samples = numpy.random.randint(100, 10000)
+    samplerate = numpy.random.randint(10, 1000)
+    samples = numpy.random.randn(n_samples)
+    sig = slab.Signal(samples, samplerate=samplerate)
+    sig2 = slab.Signal(samples, samplerate=samplerate)  # same data, samplerate
+    sig3 = slab.Signal(numpy.random.randn(n_samples), samplerate=samplerate) # different data, same samplerate
+    sig4 = slab.Signal(samples, samplerate=samplerate+1)  # same data, different samplerate
+    assert numpy.array_equal(sig.data, sig2.data)
+    assert sig.samplerate == sig2.samplerate
+    assert sig == sig2
+    assert numpy.array_equal(sig.data, sig3.data) is False
+    assert sig.samplerate == sig3.samplerate
+    assert sig != sig3
+    assert numpy.array_equal(sig.data, sig4.data)
+    assert sig.samplerate != sig4.samplerate
+    assert sig != sig4
+

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -93,3 +93,23 @@ def test_frames():
             center1 = window[frame_dur][0]
             center2 = sound[numpy.where(sound.times == center)[0][0]][0]
             numpy.testing.assert_almost_equal(center1, center2, decimal=1)
+
+
+def test_sound_equals():
+    """Test that two sounds are equal if they have the same data and samplerate."""
+    n_samples = numpy.random.randint(100, 10000)
+    samplerate = numpy.random.randint(10, 1000)
+    samples = numpy.random.randn(n_samples)
+    sig = slab.Sound(samples, samplerate=samplerate)
+    sig2 = slab.Sound(samples, samplerate=samplerate)  # same data, samplerate
+    sig3 = slab.Sound(numpy.random.randn(n_samples), samplerate=samplerate) # different data, same samplerate
+    sig4 = slab.Sound(samples, samplerate=samplerate+1)  # same data, different samplerate
+    assert numpy.array_equal(sig.data, sig2.data)
+    assert sig.samplerate == sig2.samplerate
+    assert sig == sig2
+    assert numpy.array_equal(sig.data, sig3.data) is False
+    assert sig.samplerate == sig3.samplerate
+    assert sig != sig3
+    assert numpy.array_equal(sig.data, sig4.data)
+    assert sig.samplerate != sig4.samplerate
+    assert sig != sig4


### PR DESCRIPTION
I believe that `Signal` (and any of its subclasses) is fully specified by its `data` and `samplerate`. Accordingly, I overwrote the ``__eq__`` method to check these attributes only. This should be efficient as its comparing two attributes only, not everything in the object, and it allows me to serialise/deserialise signals.