### PR TITLE
Envelope lowpass

### DIFF
--- a/slab/signal.py
+++ b/slab/signal.py
@@ -320,7 +320,7 @@ class Signal:
                 Hilbert envelope.
         """
         if apply_envelope is None:  # get the signals envelope
-            return self._get_envelope(kind)
+            return self._get_envelope(kind, cutoff)
         else:  # apply the envelope to the sound
             return self._apply_envelope(apply_envelope, times, kind)
 


### PR DESCRIPTION
Added `cutoff` argument to the `envelope` method that defaults to the formerly hard-coded value of 50 Hz. This is useful because people in the speech literature often use lower cutoffs