### PR TITLE
Specifiy number of filter is cosine filterbank

### DIFF
--- a/slab/filter.py
+++ b/slab/filter.py
@@ -327,6 +327,9 @@ class Filter(Signal):
         if n_filters is None:
             erb_spacing = Filter._freq2erb(ref_freq*2**bandwidth) - ref_erb
             n_filters = int(numpy.round((h - l) / erb_spacing))
+        elif n_filters is not None and pass_bands is False:
+            # add 2 so that after omitting pass_bands we get the desired n_filt
+            n_filters += 2
         center_freqs, erb_spacing = numpy.linspace(l, h, n_filters, retstep=True)
         if not pass_bands:
             center_freqs = center_freqs[1:-1]  # exclude low and highpass filters

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -86,17 +86,17 @@ def test_cos_filterbank():
 
 
 def test_center_freqs():
-    for i in range(100):
+    for _ in range(100):
         low_cutoff = numpy.random.randint(0, 500)
         high_cutoff = numpy.random.choice([numpy.random.randint(5000, 20000)])
-        bandwidth1 = numpy.random.uniform(0.1, 0.7)
+        bandwidth = numpy.random.uniform(0.1, 0.7)
         pass_bands = False
-        center_freqs1, bandwidth2, _ = slab.Filter._center_freqs(low_cutoff, high_cutoff, bandwidth1, pass_bands)
-        assert numpy.abs(bandwidth1 - bandwidth2) < 0.3
-        fbank = slab.Filter.cos_filterbank(5000, bandwidth1, low_cutoff, high_cutoff, pass_bands, 44100)
-        center_freqs2 = fbank.filter_bank_center_freqs()
-        assert numpy.abs(slab.Filter._erb2freq(center_freqs1[1:]) - center_freqs2[1:]).max() < 40
-        assert numpy.abs(center_freqs1 - slab.Filter._freq2erb(center_freqs2)).max() < 1
+        center_freqs1, bandwidth1, erb_spacing1 = slab.Filter._center_freqs(low_cutoff, high_cutoff, bandwidth=bandwidth, pass_bands=pass_bands)
+        n_filters = len(center_freqs1)
+        center_freqs2, bandwidth2, erb_spacing2 = slab.Filter._center_freqs(low_cutoff, high_cutoff, n_filters=n_filters, pass_bands=pass_bands)
+        assert center_freqs1 == center_freqs2
+        assert bandwidth1 == bandwidth2
+        assert erb_spacing1 == erb_spacing2
 
 
 def test_equalization():

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -62,24 +62,23 @@ def test_custom_band():
 
 
 def test_cos_filterbank():
-    for i in range(10):
+    for _ in range(10):
         sound = slab.Sound.whitenoise(duration=1.0, samplerate=44100)
         length = numpy.random.randint(1000, 5000)
         low_cutoff = numpy.random.randint(0, 500)
         high_cutoff = numpy.random.choice([numpy.random.randint(5000, 15000), None])
-        pass_bands = False
         n_filters = []
         for bandwidth in numpy.linspace(0.1, 0.9, 9):
-            fbank = slab.Filter.cos_filterbank(length, bandwidth, low_cutoff, high_cutoff, pass_bands, sound.samplerate)
+            fbank = slab.Filter.cos_filterbank(length=length, bandwidth=bandwidth, low_cutoff=low_cutoff, high_cutoff=high_cutoff, pass_bands=False, samplerate=sound.samplerate)
             n_filters.append(fbank.n_filters)
             filtsound = fbank.apply(sound)
             assert filtsound.n_channels == fbank.n_filters
             assert filtsound.n_samples == sound.n_samples
         assert all([n_filters[i] >= n_filters[i+1] for i in range(len(n_filters)-1)])
         bandwidth = numpy.random.uniform(0.1, 0.9)
-        pass_bands = True
-        fbank = slab.Filter.cos_filterbank(sound.n_samples, bandwidth, low_cutoff, high_cutoff, pass_bands,
-                                           sound.samplerate)
+        fbank = slab.Filter.cos_filterbank(
+                length=sound.n_samples, bandwidth=bandwidth, low_cutoff=low_cutoff,
+                high_cutoff=high_cutoff, pass_bands=True, samplerate=sound.samplerate)
         filtsound = fbank.apply(sound)
         collapsed = slab.Filter.collapse_subbands(filtsound, fbank)
         numpy.testing.assert_almost_equal(sound.data, collapsed.data, decimal=-1)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -90,13 +90,17 @@ def test_center_freqs():
         low_cutoff = numpy.random.randint(0, 500)
         high_cutoff = numpy.random.choice([numpy.random.randint(5000, 20000)])
         bandwidth = numpy.random.uniform(0.1, 0.7)
-        pass_bands = False
-        center_freqs1, bandwidth1, erb_spacing1 = slab.Filter._center_freqs(low_cutoff, high_cutoff, bandwidth=bandwidth, pass_bands=pass_bands)
-        n_filters = len(center_freqs1)
-        center_freqs2, bandwidth2, erb_spacing2 = slab.Filter._center_freqs(low_cutoff, high_cutoff, n_filters=n_filters, pass_bands=pass_bands)
-        assert center_freqs1 == center_freqs2
+        center_freqs1, bandwidth1, erb_spacing1 = slab.Filter._center_freqs(low_cutoff, high_cutoff, bandwidth=bandwidth, pass_bands=False)
+        center_freqs2, bandwidth2, erb_spacing2 = slab.Filter._center_freqs(low_cutoff, high_cutoff, bandwidth=bandwidth, pass_bands=True)
+        assert all(center_freqs1 == center_freqs2[1:-1])
+        assert len(center_freqs1) == len(center_freqs2)-2
         assert bandwidth1 == bandwidth2
         assert erb_spacing1 == erb_spacing2
+        n_filters = len(center_freqs1)
+        center_freqs3, bandwidth3, erb_spacing3 = slab.Filter._center_freqs(low_cutoff, high_cutoff, n_filters=n_filters, pass_bands=False)
+        assert all(center_freqs1 == center_freqs3)
+        assert bandwidth1 == bandwidth3
+        assert erb_spacing1 == erb_spacing3
 
 
 def test_equalization():


### PR DESCRIPTION
I've added an `n_filters` argument to `slab.Filter.cos_filterbank` and `slab.Filter.center_freqs` so that one can directly specify the desired number of filters (bandwidth argument is ignored in that case).

The concrete use case is that I wanted to create a 16-band spectrogram of a given signal, and realized that there was no straight forward way of doing this in slab.

I also updated the docstring and the test function of `test_center_freqs` to make sure that specifying bandwidth and number of filter produces the same results